### PR TITLE
ヘッダータップ時にプロフィールに遷移する処理を追加

### DIFF
--- a/iOS-UISample/Util/Extension/UIView+.swift
+++ b/iOS-UISample/Util/Extension/UIView+.swift
@@ -18,4 +18,17 @@ extension UIView {
             addSubview(view)
         }
     }
+
+    /// UIViewから親のViewControllerを取得する処理
+    /// 引用: https://qiita.com/tetsukick/items/ae05fdc6040c491639a2
+    func parentViewController() -> UIViewController? {
+        var parentResponder: UIResponder? = self
+        while true {
+            guard let nextResponder = parentResponder?.next else { return nil }
+            if let viewController = nextResponder as? UIViewController {
+                return viewController
+            }
+            parentResponder = nextResponder
+        }
+    }
 }

--- a/iOS-UISample/View/SampleTableHeaderCollectionViewCell.swift
+++ b/iOS-UISample/View/SampleTableHeaderCollectionViewCell.swift
@@ -11,24 +11,56 @@ final class SampleTableHeaderCollectionViewCell: UICollectionViewCell {
 
     // MARK: - Properties
 
+    @IBOutlet weak private var wrapperView: UIView!
     @IBOutlet weak private var avatarImageView: UIImageView! {
         didSet {
             avatarImageView.contentMode = .scaleAspectFill
+            let tapGesture = UITapGestureRecognizer(
+                target: self,
+                action: #selector(avatarImageViewTapped))
+            avatarImageView.isUserInteractionEnabled = true
+            avatarImageView.addGestureRecognizer(tapGesture)
         }
     }
+
+    private var user: User?
 
     // MARK: - LifeCycle
 
     override func layoutSubviews() {
         super.layoutSubviews()
-        avatarImageView.layer.cornerRadius = avatarImageView.frame.height / 2
+        configureUI()
+    }
+
+    // MARK: - Selectors
+
+    @objc func avatarImageViewTapped() {
+        guard let user = user else { return }
+
+        // 閲覧済みユーザーであることがわかるよう枠線の色を変更
+        wrapperView.layer.borderColor = UIColor.lightGray.cgColor
+
+        // FIXME: 親のViewControllerを取得して遷移する
+        if let parentVC = self.parentViewController() {
+            let profileVC = ProfileViewController(user: user)
+            parentVC.navigationController?.pushViewController(profileVC, animated: true)
+        }
     }
 
     // MARK: - Helpers
 
     func configure(user: User) {
+        self.user = user
         guard let imageName = user.image else { return }
         let image = UIImage.named(imageName)
         avatarImageView.image = image
     }
+
+    private func configureUI() {
+        wrapperView.layer.borderColor = UIColor.systemRed.cgColor
+        wrapperView.layer.borderWidth = 2
+        wrapperView.layer.cornerRadius = wrapperView.frame.height / 2
+        avatarImageView.layer.cornerRadius = avatarImageView.frame.height / 2
+    }
+
 }

--- a/iOS-UISample/View/SampleTableHeaderCollectionViewCell.xib
+++ b/iOS-UISample/View/SampleTableHeaderCollectionViewCell.xib
@@ -22,15 +22,15 @@
                         <rect key="frame" x="0.0" y="0.0" width="80" height="80"/>
                         <subviews>
                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="H9Z-jZ-mJb">
-                                <rect key="frame" x="0.0" y="0.0" width="80" height="80"/>
+                                <rect key="frame" x="4" y="4" width="72" height="72"/>
                             </imageView>
                         </subviews>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
-                            <constraint firstAttribute="trailing" secondItem="H9Z-jZ-mJb" secondAttribute="trailing" id="2ks-1k-mIm"/>
-                            <constraint firstAttribute="bottom" secondItem="H9Z-jZ-mJb" secondAttribute="bottom" id="5S2-yh-0aJ"/>
-                            <constraint firstItem="H9Z-jZ-mJb" firstAttribute="leading" secondItem="PLO-AL-eeA" secondAttribute="leading" id="a00-sU-dsg"/>
-                            <constraint firstItem="H9Z-jZ-mJb" firstAttribute="top" secondItem="PLO-AL-eeA" secondAttribute="top" id="mFg-ro-AAO"/>
+                            <constraint firstAttribute="trailing" secondItem="H9Z-jZ-mJb" secondAttribute="trailing" constant="4" id="2ks-1k-mIm"/>
+                            <constraint firstAttribute="bottom" secondItem="H9Z-jZ-mJb" secondAttribute="bottom" constant="4" id="5S2-yh-0aJ"/>
+                            <constraint firstItem="H9Z-jZ-mJb" firstAttribute="leading" secondItem="PLO-AL-eeA" secondAttribute="leading" constant="4" id="a00-sU-dsg"/>
+                            <constraint firstItem="H9Z-jZ-mJb" firstAttribute="top" secondItem="PLO-AL-eeA" secondAttribute="top" constant="4" id="mFg-ro-AAO"/>
                         </constraints>
                     </view>
                 </subviews>
@@ -44,6 +44,7 @@
             </constraints>
             <connections>
                 <outlet property="avatarImageView" destination="H9Z-jZ-mJb" id="aDG-mR-Uqe"/>
+                <outlet property="wrapperView" destination="PLO-AL-eeA" id="JMd-wP-Qd9"/>
             </connections>
             <point key="canvasLocation" x="55" y="121"/>
         </collectionViewCell>

--- a/iOS-UISample/View/SampleTableHeaderView.swift
+++ b/iOS-UISample/View/SampleTableHeaderView.swift
@@ -119,8 +119,8 @@ final class SampleTableHeaderView: UITableViewHeaderFooterView {
 extension SampleTableHeaderView: UICollectionViewDelegate {
 
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-        guard let user = users[safe: indexPath.row] else { return }
-        delegate?.didTapProfileImage(self, didSelectUser: user)
+//        guard let user = users[safe: indexPath.row] else { return }
+//        delegate?.didTapProfileImage(self, didSelectUser: user)
     }
 }
 

--- a/iOS-UISample/ViewController/SampleTableViewController.swift
+++ b/iOS-UISample/ViewController/SampleTableViewController.swift
@@ -175,8 +175,9 @@ extension SampleTableViewController: UITableViewDataSource {
 
 extension SampleTableViewController: SampleTableHeaderViewDelegate {
 
+    /// セルタップ時に呼ばれるDelgateメソッド
     func didTapProfileImage(_ header: SampleTableHeaderView, didSelectUser user: User) {
-        let vc = ProfileViewController(user: user)
-        navigationController?.pushViewController(vc, animated: true)
+//        let vc = ProfileViewController(user: user)
+//        navigationController?.pushViewController(vc, animated: true)
     }
 }


### PR DESCRIPTION
## 実現したいこと
おすすめのユーザーのViewをタップした際に、枠線の色変更と画面遷移のイベントを同時に呼びたいです。
想定する動作としてはインスタグラムやTwitterのストーリーのようなイメージです。

<img src="https://user-images.githubusercontent.com/54096246/106440256-f959b580-64bb-11eb-936d-a193a5ef5998.png" width="240px">

## 質問したいこと

### 質問1
- UIViewに画面遷移の処理を持たせるのは、画面遷移処理のロジックが分散するので好ましくないという認識であっているでしょうか？

### 質問2
- ViewControllerで直接参照を持っていない、「TableViewのヘッダーの中のCollectionViewのセルの中のUIImageView」から
ViewControllerにイベントを通知して画面遷移するにはどういった実装方法がいいでしょうか？

## 説明
タップ時にImageViewの色を変更するためにImageView側でイベントを設定すると、
Header内の`collectionView didSelectItemAt~`でdelegateメソッドを呼んで画面遷移の処理をViewController側で行う処理が呼ばれなくなります。

ViewControllerが対象のImageViewの参照を持っていれば、`imageView.delegate = self`として設定できますが、
参照を持っているのはHeader側でなのでその方法だとできなそうです。

View側で親のViewControllerを取得すれば色変更と画面遷移が同時にできますが、質問1の認識があっていればよくない実装に思います。

他に想定できる方法としてはViewでdelegateを実装してHeaderに通知、
Headerで準拠したViewのdelegateメソッド内で、さらにHeaderで定義した新規のdelegateメソッドを呼び出し、
ViewControllerに通知する方法を思いつきました。
その場合、Viewの階層が深くなるごとに実装するdelegateの数が増えるという点が問題に思えます。